### PR TITLE
tweak YARD

### DIFF
--- a/lib/hydra/works/services/determine_original_name.rb
+++ b/lib/hydra/works/services/determine_original_name.rb
@@ -1,7 +1,7 @@
 module Hydra::Works
   class DetermineOriginalName
     # Determines the original name for a given file
-    # @param [IO, File, Rack::Multipart::UploadedFile, #read] file
+    # @param [IO, File, Rack::Multipart::UploadedFile] file
     # @return [String]
     def self.call(file)
       return file.original_name if file.respond_to?(:original_name)


### PR DESCRIPTION
If you aren't calling `#read`, then it isn't part of the method signature.