### PR TITLE
Test reversed nested collection relationships

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ group :development, :test do
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
 end
+
+gem 'hydra-pcdm', git: 'https://github.com/samvera/hydra-pcdm.git', branch: 'nested_collection_reverse_relationship'

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,3 @@ group :development, :test do
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
 end
-
-gem 'hydra-pcdm', git: 'https://github.com/samvera/hydra-pcdm.git', branch: 'nested_collection_reverse_relationship'

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-derivatives', '~> 3.0'
   spec.add_dependency 'hydra-file_characterization', '~> 0.3', '>= 0.3.3'
   spec.add_dependency 'om', '~> 3.1'
+  spec.add_dependency 'activesupport', '>= 4.2.10', '< 5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/hydra/works/models/collection_spec.rb
+++ b/spec/hydra/works/models/collection_spec.rb
@@ -118,6 +118,18 @@ describe Hydra::Works::Collection do
     it { is_expected.to eq [collection1] }
   end
 
+  describe 'member_of_collections' do
+    let(:collection1) { described_class.create }
+    before do
+      collection.member_of_collections = [collection1]
+    end
+
+    it 'is a member of the collection' do
+      expect(collection.member_of_collections).to eq [collection1]
+      expect(collection.member_of_collection_ids).to eq [collection1.id]
+    end
+  end
+
   describe 'adding file_sets to collections' do
     let(:file_set) { Hydra::Works::FileSet.new }
     let(:exception) { ActiveFedora::AssociationTypeMismatch }


### PR DESCRIPTION
This PR mirrors the one made by @escowles (#303) when reversing the collection->object relationship.  All of the work happens in hydra-pcdm so only tests need to be added here.  This PR points to the branch of hydra-pcdm which has the changes, but it should use a released version when available.