### PR TITLE
Fix #334 - Add a cleanup phase to CharacterizationService

### DIFF
--- a/lib/hydra/works/characterization/fits_document.rb
+++ b/lib/hydra/works/characterization/fits_document.rb
@@ -146,6 +146,20 @@ module Hydra::Works::Characterization
       t.frame_rate(proxy: [:metadata, :video, :frame_rate])
     end
 
+    # Cleanup phase; ugly name to avoid collisions.
+    # The send construct here is required to fix up values because the setters
+    # are not defined, but rather applied with method_missing.
+    def __cleanup__
+      # Sometimes, FITS reports the mimetype attribute as a comma-separated string.
+      # All terms are arrays and, in this case, there is only one element, so scan the first.
+      if file_mime_type.present? && file_mime_type.first.include?(',')
+        send("file_mime_type=", [file_mime_type.first.split(',').first])
+      end
+
+      # Add any other scrubbers here; don't return any particular value
+      nil
+    end
+
     def self.xml_template
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.fits(xmlns: 'http://hul.harvard.edu/ois/xml/ns/fits/fits_output',

--- a/lib/hydra/works/services/characterization_service.rb
+++ b/lib/hydra/works/services/characterization_service.rb
@@ -62,6 +62,7 @@ module Hydra::Works
       def parse_metadata(metadata)
         omdoc = parser_class.new
         omdoc.ng_xml = Nokogiri::XML(metadata) if metadata.present?
+        omdoc.__cleanup__ if omdoc.respond_to? :__cleanup__
         characterization_terms(omdoc)
       end
 

--- a/spec/fixtures/fits_netcdf_two_mimetypes.xml
+++ b/spec/fixtures/fits_netcdf_two_mimetypes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The netCDF file analzyed to produce this output was madis-raob.nc from https://www.unidata.ucar.edu/software/netcdf/examples/files.html -->
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="2/7/18 10:03 PM">
+  <identification status="SINGLE_RESULT">
+    <identity format="netCDF-3 Classic" mimetype="application/netcdf, application/x-netcdf" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/282</externalIdentifier>
+    </identity>
+  </identification>
+  <fileinfo>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/madis-raob.nc</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">madis-raob.nc</filename>
+    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">150612</size>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">47b926e988723c65f0cdaf4117f4ef4d</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1347484346000</fslastmodified>
+  </fileinfo>
+  <filestatus />
+  <metadata />
+  <statistics fitsExecutionTime="1000">
+    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+    <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="192" />
+    <tool toolname="Jhove" toolversion="1.16" executionTime="993" />
+    <tool toolname="file utility" toolversion="5.25" executionTime="532" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="532" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="188" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="506" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="284" />
+  </statistics>
+</fits>
+

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -123,6 +123,15 @@ describe Hydra::Works::CharacterizationService do
       end
     end
 
+    context 'using netCDF metadata' do
+      let(:fits_filename) { 'fits_netcdf_two_mimetypes.xml' }
+      let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
+
+      it 'reports the correct, single MIME type' do
+        expect(file.mime_type).to eq("application/netcdf")
+      end
+    end
+
     context 'using image metadata' do
       let(:fits_filename) { 'fits_0.8.5_jp2.xml' }
       let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }


### PR DESCRIPTION
This is a little suboptimal because OM exposes all of the terms on the
top level of the instance, so the method is named __cleanup__. The
parsers also do not have a base class to ensure that a given cleanup
method is available, so we use a respond_to? check. The last ugly bit is
that calling `file_mime_type = ...` did not update the value, so the
`send("filetype=", ...)` was the only way I could get this to pass.

There is a new test with FITS output from running against a sample
netCDF file. There may be other types that report multiple mimetypes in
this way, so the cleanup implementation is general (split on comma, pick
the first). It's possible that using an array would be better, but there
are other expectations in the service that enforce a single value.