### PR TITLE
Fix characterization of audio and video files with Fits 1.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'lib/hydra/works/characterization/fits_document.rb'
     - 'spec/**/*.rb'
 
 # By default RSpec/MessageSpies has the following:

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-derivatives', '~> 3.0'
   spec.add_dependency 'hydra-file_characterization', '~> 0.3', '>= 0.3.3'
   spec.add_dependency 'om', '~> 3.1'
+  spec.add_dependency 'activesupport', '>= 4.2.10', '< 5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/hydra/works/characterization.rb
+++ b/lib/hydra/works/characterization.rb
@@ -9,10 +9,11 @@ module Hydra::Works
       end
 
       def mapper_defaults
-        { audio_duration: :duration, audio_sample_rate: :sample_rate,
-          file_author: :creator, file_language: :language, file_mime_type: :mime_type,
-          video_audio_sample_rate: :sample_rate, video_duration: :duration, video_height: :height,
-          video_sample_rate: :sample_rate, video_width: :width }
+        { file_author: :creator, file_language: :language, file_mime_type: :mime_type,
+          audio_duration: :duration, audio_sample_rate: :sample_rate, audio_bit_rate: :bit_rate,
+          video_audio_sample_rate: :sample_rate, track_frame_rate: :frame_rate,
+          video_duration: :duration, video_sample_rate: :sample_rate, video_bit_rate: :bit_rate,
+          video_width: :width, video_track_width: :width, video_height: :height, video_track_height: :height }
       end
     end
 

--- a/lib/hydra/works/characterization/fits_document.rb
+++ b/lib/hydra/works/characterization/fits_document.rb
@@ -72,18 +72,26 @@ module Hydra::Works::Characterization
         t.audio do
           t.duration(path: 'duration')
           t.bit_depth(path: 'bitDepth')
+          t.bit_rate(path: 'bitRate')
           t.sample_rate(path: 'sampleRate')
           t.channels(path: 'channels')
           t.data_format(path: 'dataFormatType')
           t.offset(path: 'offset')
         end
         t.video do
-          t.width(path: 'imageWidth')
-          t.height(path: 'imageHeight')
+          t.width(path: 'imageWidth') # for fits_0.8.5
+          t.height(path: 'imageHeight') # for fits_0.8.5
           t.duration(path: 'duration')
-          t.sample_rate(path: 'sampleRate')
-          t.audio_sample_rate(path: 'audioSampleRate')
-          t.frame_rate(path: 'frameRate')
+          t.bit_rate(path: 'bitRate') # for fits_1.2.0
+          t.sample_rate(path: 'sampleRate') # for fits_0.8.5
+          t.audio_sample_rate(path: 'audioSampleRate') # for fits_0.8.5
+          t.frame_rate(path: 'frameRate') # for fits_0.8.5
+          t.track(path: 'track', attributes: { type: 'video' }) do # for fits_1.2.0
+            t.width(path: 'width')
+            t.height(path: 'height')
+            t.aspect_ratio(path: 'aspectRatio')
+            t.frame_rate(path: 'frameRate')
+          end
         end
       end
       # fits_version needs a different name than it's target node since they're at the same level
@@ -117,8 +125,10 @@ module Hydra::Works::Characterization
       t.compression(proxy: [:metadata, :image, :compression])
       t.width(proxy: [:metadata, :image, :width])
       t.video_width(proxy: [:metadata, :video, :width])
+      t.video_track_width(proxy: [:metadata, :video, :track, :width])
       t.height(proxy: [:metadata, :image, :height])
       t.video_height(proxy: [:metadata, :video, :height])
+      t.video_track_height(proxy: [:metadata, :video, :track, :height])
       t.color_space(proxy: [:metadata, :image, :color_space])
       t.profile_name(proxy: [:metadata, :image, :profile_name])
       t.profile_version(proxy: [:metadata, :image, :profile_version])
@@ -144,6 +154,10 @@ module Hydra::Works::Characterization
       t.data_format(proxy: [:metadata, :audio, :data_format])
       t.offset(proxy: [:metadata, :audio, :offset])
       t.frame_rate(proxy: [:metadata, :video, :frame_rate])
+      t.audio_bit_rate(proxy: [:metadata, :audio, :bit_rate])
+      t.video_bit_rate(proxy: [:metadata, :video, :bit_rate])
+      t.track_frame_rate(proxy: [:metadata, :video, :track, :frame_rate])
+      t.aspect_ratio(proxy: [:metadata, :video, :track, :aspect_ratio])
     end
 
     # Cleanup phase; ugly name to avoid collisions.

--- a/lib/hydra/works/characterization/schema/audio_schema.rb
+++ b/lib/hydra/works/characterization/schema/audio_schema.rb
@@ -4,6 +4,8 @@ module Hydra::Works::Characterization
     property :channels, predicate: RDF::Vocab::NFO.channels
     property :data_format, predicate: RDF::Vocab::EBUCore.hasDataFormat
     property :frame_rate, predicate: RDF::Vocab::NFO.frameRate
+    # bit_rate might be an array containing multiple values
+    property :bit_rate, predicate: RDF::Vocab::EBUCore.bitRate
     property :duration, predicate: RDF::Vocab::NFO.duration
     property :sample_rate, predicate: RDF::Vocab::EBUCore.sampleRate
     # properties without cannonical URIs

--- a/lib/hydra/works/characterization/schema/video_schema.rb
+++ b/lib/hydra/works/characterization/schema/video_schema.rb
@@ -3,7 +3,9 @@ module Hydra::Works::Characterization
     property :height, predicate: RDF::Vocab::EBUCore.height
     property :width, predicate: RDF::Vocab::EBUCore.width
     property :frame_rate, predicate: RDF::Vocab::NFO.frameRate
+    property :bit_rate, predicate: RDF::Vocab::EBUCore.bitRate
     property :duration, predicate: RDF::Vocab::NFO.duration
     property :sample_rate, predicate: RDF::Vocab::EBUCore.sampleRate
+    property :aspect_ratio, predicate: RDF::Vocab::EBUCore.aspectRatio
   end
 end

--- a/spec/fixtures/fits_1.2.0_avi.xml
+++ b/spec/fixtures/fits_1.2.0_avi.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="4/4/18 4:12 PM">
+  <identification status="CONFLICT">
+    <identity format="AVI" mimetype="video/avi" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="MediaInfo" toolversion="0.7.75" />
+    </identity>
+    <identity format="Audio/Video Interleaved Format" mimetype="video/x-msvideo" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="file utility" toolversion="5.31" />
+      <tool toolname="ffident" toolversion="0.2" />
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/5</externalIdentifier>
+    </identity>
+  </identification>
+  <fileinfo>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/cjcolvar/Documents/Code/samvera/hydra-works/spec/fixtures/countdown.avi</filepath>
+    <filename toolname="MediaInfo" toolversion="0.7.75">countdown.avi</filename>
+    <size toolname="MediaInfo" toolversion="0.7.75">723678</size>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">d43ffafa098925dae10feeca46dc9a87</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1522855873000</fslastmodified>
+  </fileinfo>
+  <filestatus />
+  <metadata>
+    <video>
+      <location toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">/Users/cjcolvar/Documents/Code/samvera/hydra-works/spec/fixtures/countdown.avi</location>
+      <mimeType toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">video/avi</mimeType>
+      <format toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">AVI</format>
+      <duration toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">14148</duration>
+      <bitRate toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">409204</bitRate>
+      <dateModified toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">UTC 2018-04-04 15:31:13</dateModified>
+      <track type="video" id="0" toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">
+        <videoDataEncoding>CRAM</videoDataEncoding>
+        <codecId>CRAM</codecId>
+        <codecCC>CRAM</codecCC>
+        <codecName>CRAM</codecName>
+        <codecInfo>Microsoft Video 1</codecInfo>
+        <compression>Unknown</compression>
+        <byteOrder>Unknown</byteOrder>
+        <bitDepth>8 bits</bitDepth>
+        <bitRate>313826</bitRate>
+        <duration>14100</duration>
+        <delay>0</delay>
+        <trackSize>553118</trackSize>
+        <width>356 pixels</width>
+        <height>264 pixels</height>
+        <frameRate>10.000</frameRate>
+        <frameCount>141</frameCount>
+        <aspectRatio>4:3</aspectRatio>
+      </track>
+      <track type="audio" id="1" toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">
+        <audioDataEncoding>PCM</audioDataEncoding>
+        <codecId>1</codecId>
+        <codecFamily>PCM</codecFamily>
+        <compression>none</compression>
+        <bitRate>88200</bitRate>
+        <bitRateMode>Constant</bitRateMode>
+        <bitDepth>8 bits</bitDepth>
+        <duration>14148</duration>
+        <delay>0</delay>
+        <trackSize>155980</trackSize>
+        <samplingRate>11025</samplingRate>
+        <numSamples>155982</numSamples>
+        <channels>1</channels>
+        <byteOrder>Little</byteOrder>
+      </track>
+    </video>
+  </metadata>
+  <statistics fitsExecutionTime="692">
+    <tool toolname="MediaInfo" toolversion="0.7.75" executionTime="662" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+    <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="273" />
+    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
+    <tool toolname="file utility" toolversion="5.31" executionTime="644" />
+    <tool toolname="Exiftool" toolversion="10.00" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="80" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="555" />
+    <tool toolname="Tika" toolversion="1.10" status="did not run" />
+  </statistics>
+</fits>
+

--- a/spec/fixtures/fits_1.2.0_mp3.xml
+++ b/spec/fixtures/fits_1.2.0_mp3.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="4/4/18 4:13 PM">
+  <identification>
+    <identity format="MPEG 1/2 Audio Layer 3" mimetype="audio/mpeg" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="Exiftool" toolversion="10.00" />
+      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
+      <tool toolname="ffident" toolversion="0.2" />
+      <tool toolname="Tika" toolversion="1.10" />
+      <version toolname="NLNZ Metadata Extractor" toolversion="3.6GA">1</version>
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/134</externalIdentifier>
+    </identity>
+  </identification>
+  <fileinfo>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/cjcolvar/Documents/Code/samvera/hydra-works/spec/fixtures/test5.mp3</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">test5.mp3</filename>
+    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">366464</size>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">d98da8d92c397294164b02a0382eb0e6</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1522855873000</fslastmodified>
+  </fileinfo>
+  <filestatus />
+  <metadata>
+    <audio>
+      <duration toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">0:0:15:261</duration>
+      <bitRate toolname="Exiftool" toolversion="10.00" status="CONFLICT">192 kbps</bitRate>
+      <bitRate toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">192000</bitRate>
+      <sampleRate toolname="Exiftool" toolversion="10.00">44100</sampleRate>
+      <channels toolname="Exiftool" toolversion="10.00">2</channels>
+      <milliseconds toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">15261</milliseconds>
+      <author toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Hendrik Broekman</author>
+      <title toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">BachGavotteShort</title>
+      <sampleRate toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">44100</sampleRate>
+    </audio>
+  </metadata>
+  <statistics fitsExecutionTime="2609">
+    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+    <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="1557" />
+    <tool toolname="Jhove" toolversion="1.16" executionTime="2561" />
+    <tool toolname="file utility" toolversion="5.31" executionTime="1513" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="1568" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="1251" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="463" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="1315" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="640" />
+  </statistics>
+</fits>
+

--- a/spec/fixtures/fits_1.2.0_mp4.xml
+++ b/spec/fixtures/fits_1.2.0_mp4.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="4/4/18 3:02 PM">
+  <identification status="CONFLICT">
+    <identity format="Quicktime" mimetype="video/quicktime" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="MediaInfo" toolversion="0.7.75" />
+    </identity>
+    <identity format="MPEG-4 Media File" mimetype="application/mp4, video/mp4" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/199</externalIdentifier>
+    </identity>
+    <identity format="ISO Media, MP4 v2 [ISO 14496-14]" mimetype="video/mp4" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="file utility" toolversion="5.22" />
+    </identity>
+  </identification>
+  <fileinfo>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/home/app/avalon/tmp/original_file.mp4</filepath>
+    <filename toolname="MediaInfo" toolversion="0.7.75">original_file.mp4</filename>
+    <size toolname="MediaInfo" toolversion="0.7.75">199160</size>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">7ae24368ccb7a6c6422a14ff73f33c9a</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1522853877000</fslastmodified>
+  </fileinfo>
+  <filestatus />
+  <metadata>
+    <video>
+      <location toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">/home/app/avalon/tmp/original_file.mp4</location>
+      <mimeType toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">Quicktime</format>
+      <formatProfile toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">Base Media / Version 2</formatProfile>
+      <duration toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">6315</duration>
+      <bitRate toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">252301</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">UTC 2010-09-23 00:37:25</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">UTC 2018-04-04 14:57:57</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">
+        <videoDataEncoding>avc1</videoDataEncoding>
+        <codecId>avc1</codecId>
+        <codecCC>avc1</codecCC>
+        <codecVersion>Main@L1.1</codecVersion>
+        <codecName>AVC</codecName>
+        <codecFamily>H.264</codecFamily>
+        <codecInfo>Advanced Video Codec</codecInfo>
+        <compression>Unknown</compression>
+        <byteOrder>Unknown</byteOrder>
+        <bitDepth>8 bits</bitDepth>
+        <bitRate>74477</bitRate>
+        <duration>6282</duration>
+        <trackSize>58482</trackSize>
+        <width>200 pixels</width>
+        <height>110 pixels</height>
+        <frameRate>24.390</frameRate>
+        <frameRateMode>Variable</frameRateMode>
+        <frameCount>149</frameCount>
+        <aspectRatio>16:9</aspectRatio>
+        <scanningFormat>Progressive</scanningFormat>
+        <chromaSubsampling>4:2:0</chromaSubsampling>
+        <colorspace>YUV</colorspace>
+      </track>
+      <track type="audio" id="2" toolname="MediaInfo" toolversion="0.7.75" status="SINGLE_RESULT">
+        <audioDataEncoding>AAC</audioDataEncoding>
+        <codecId>40</codecId>
+        <codecFamily>AAC</codecFamily>
+        <compression>Lossy</compression>
+        <bitRate>201736</bitRate>
+        <bitRateMode>Variable</bitRateMode>
+        <duration>6315</duration>
+        <trackSize>134999</trackSize>
+        <soundField>Front: C</soundField>
+        <samplingRate>48000</samplingRate>
+        <numSamples>303120</numSamples>
+        <channels>1</channels>
+      </track>
+    </video>
+  </metadata>
+  <statistics fitsExecutionTime="266">
+    <tool toolname="MediaInfo" toolversion="0.7.75" executionTime="252" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+    <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="103" />
+    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
+    <tool toolname="file utility" toolversion="5.22" executionTime="227" />
+    <tool toolname="Exiftool" toolversion="10.00" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="95" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="198" />
+    <tool toolname="Tika" toolversion="1.10" status="did not run" />
+  </statistics>
+</fits>

--- a/spec/hydra/works/characterization_spec.rb
+++ b/spec/hydra/works/characterization_spec.rb
@@ -60,14 +60,17 @@ describe Hydra::Works::Characterization do
       it { is_expected.to respond_to(:height) }
       it { is_expected.to respond_to(:width) }
       it { is_expected.to respond_to(:frame_rate) }
+      it { is_expected.to respond_to(:bit_rate) }
       it { is_expected.to respond_to(:duration) }
       it { is_expected.to respond_to(:sample_rate) }
+      it { is_expected.to respond_to(:aspect_ratio) }
     end
     context "with Audio schema" do
       it { is_expected.to respond_to(:bit_depth) }
       it { is_expected.to respond_to(:channels) }
       it { is_expected.to respond_to(:data_format) }
       it { is_expected.to respond_to(:frame_rate) }
+      it { is_expected.to respond_to(:bit_rate) }
       it { is_expected.to respond_to(:duration) }
       it { is_expected.to respond_to(:sample_rate) }
       it { is_expected.to respond_to(:offset) }
@@ -77,16 +80,21 @@ describe Hydra::Works::Characterization do
   describe "::mapper" do
     let(:mapper_keys) do
       [
-        :audio_duration,
-        :audio_sample_rate,
         :file_author,
         :file_language,
         :file_mime_type,
+        :audio_duration,
+        :audio_sample_rate,
+        :audio_bit_rate,
         :video_audio_sample_rate,
+        :track_frame_rate,
         :video_duration,
-        :video_height,
         :video_sample_rate,
-        :video_width
+        :video_bit_rate,
+        :video_width,
+        :video_track_width,
+        :video_height,
+        :video_track_height
       ]
     end
     subject { described_class.mapper.keys }

--- a/spec/hydra/works/models/concerns/file_set/contained_files_spec.rb
+++ b/spec/hydra/works/models/concerns/file_set/contained_files_spec.rb
@@ -1,21 +1,8 @@
 require 'spec_helper'
 
 describe Hydra::Works::ContainedFiles do
-  let(:file_set) do
-    Hydra::Works::FileSet.create
-  end
-
-  let(:thumbnail) do
-    file = file_set.files.build
-    Hydra::PCDM::AddTypeToFile.call(file, pcdm_thumbnail_uri)
-  end
-
-  let(:file)                { file_set.files.build }
-  let(:pcdm_thumbnail_uri)  { ::RDF::URI('http://pcdm.org/use#ThumbnailImage') }
-
-  before do
-    file_set.files = [file]
-  end
+  let(:file_set) { Hydra::Works::FileSet.create }
+  let(:pcdm_thumbnail_uri) { ::RDF::URI('http://pcdm.org/use#ThumbnailImage') }
 
   describe '#thumbnail' do
     context 'when a thumbnail is present' do
@@ -63,7 +50,7 @@ describe Hydra::Works::ContainedFiles do
       end
       it 'retains origin pcdm.File RDF type' do
         expect(subject.metadata_node.type).to include(::RDF::URI('http://pcdm.org/use#OriginalFile'))
-        expect(file_set.original_file.metadata_node.type).to include(Hydra::PCDM::Vocab::PCDMTerms.File)
+        expect(subject.metadata_node.type).to include(Hydra::PCDM::Vocab::PCDMTerms.File)
       end
     end
 

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -81,20 +81,24 @@ describe Hydra::Works::CharacterizationService do
   end
 
   context "passing an object that does not have matching properties" do
-    let!(:current_schemas) { ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas }
-
     let(:characterization) { class_double("Hydra::FileCharacterization").as_stubbed_const }
     let(:fits_filename)    { 'fits_0.8.5_pdf.xml' }
     let(:fits_response)    { IO.read(File.join(fixture_path, fits_filename)) }
     let(:file_content)     { 'dummy content' }
     let(:file)             { Hydra::PCDM::File.new { |f| f.content = file_content } }
 
-    before do
+    around do |example|
+      @current_schemas = ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas
+      @metadata_schema = Hydra::PCDM::File::GeneratedMetadataSchema
       ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas = [ActiveFedora::WithMetadata::DefaultSchema]
-      allow(characterization).to receive(:characterize).and_return(fits_response)
+      example.run
+      ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas = @current_schemas
+      # This next line required to force resetting the metadata schema class used by Hydra::PCDM::File
+      Hydra::PCDM::File.instance_variable_set(:@metadata_schema, @metadata_schema)
     end
-    after do
-      ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas = [current_schemas]
+
+    before do
+      allow(characterization).to receive(:characterize).and_return(fits_response)
     end
 
     it 'does not explode with an error' do
@@ -133,50 +137,78 @@ describe Hydra::Works::CharacterizationService do
     end
 
     context 'using image metadata' do
-      let(:fits_filename) { 'fits_0.8.5_jp2.xml' }
       let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
 
-      it 'assigns expected values to image properties.' do
-        expect(file.file_size).to eq(["11043"])
-        expect(file.byte_order).to eq(["big endian"])
-        expect(file.compression).to contain_exactly("JPEG 2000 Lossless", "JPEG 2000")
-        expect(file.width).to eq(["512"])
-        expect(file.height).to eq(["465"])
-        expect(file.color_space).to eq(["sRGB"])
+      context 'with fits_0.8.5' do
+        let(:fits_filename) { 'fits_0.8.5_jp2.xml' }
+        it 'assigns expected values to image properties.' do
+          expect(file.file_size).to eq(["11043"])
+          expect(file.byte_order).to eq(["big endian"])
+          expect(file.compression).to contain_exactly("JPEG 2000 Lossless", "JPEG 2000")
+          expect(file.width).to eq(["512"])
+          expect(file.height).to eq(["465"])
+          expect(file.color_space).to eq(["sRGB"])
+        end
       end
-    end
 
-    context 'using image metadata' do
-      let(:fits_filename) { 'fits_1.2.0_jpg.xml' }
-      let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
-
-      it 'ensures duplicate values are not returned for exifVersion, dateCreated, dateModified.' do
-        expect(file.exif_version).to eq(["0221"])
-        expect(file.date_created).to eq(["2009:02:04 11:05:25.36-06:00"])
-        expect(file.date_modified).to eq(["2009:02:04 16:10:47"])
+      context 'with fits_1.2.0' do
+        let(:fits_filename) { 'fits_1.2.0_jpg.xml' }
+        it 'ensures duplicate values are not returned for exifVersion, dateCreated, dateModified.' do
+          expect(file.exif_version).to eq(["0221"])
+          expect(file.date_created).to eq(["2009:02:04 11:05:25.36-06:00"])
+          expect(file.date_modified).to eq(["2009:02:04 16:10:47"])
+        end
       end
     end
 
     context 'using video metadata' do
-      let(:fits_filename) { 'fits_0.8.5_avi.xml' }
       let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
 
-      it 'assigns expected values to video properties.' do
-        expect(file.height).to eq(["264"])
-        expect(file.width).to eq(["356"])
-        expect(file.duration).to eq(["14.10 s"])
-        expect(file.frame_rate).to eq(["10"])
-        expect(file.sample_rate).to eq(["11025"])
+      context 'with fits_0.8.5' do
+        let(:fits_filename) { 'fits_0.8.5_avi.xml' }
+        it 'assigns expected values to video properties.' do
+          expect(file.height).to eq(["264"])
+          expect(file.width).to eq(["356"])
+          expect(file.duration).to eq(["14.10 s"])
+          expect(file.frame_rate).to eq(["10"])
+          expect(file.sample_rate).to eq(["11025"])
+        end
+      end
+
+      context 'with fits_1.2.0' do
+        let(:fits_filename) { 'fits_1.2.0_avi.xml' }
+        it 'assigns expected values to video properties.' do
+          expect(file.height).to eq(["264"])
+          expect(file.width).to eq(["356"])
+          expect(file.duration).to eq(["14148"])
+          expect(file.frame_rate).to eq(["10.000"])
+          expect(file.bit_rate).to eq(["409204"])
+          expect(file.aspect_ratio).to eq(["4:3"])
+        end
       end
     end
+
     context 'using audio metadata' do
-      let(:fits_filename) { 'fits_0.8.5_mp3.xml' }
       let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
 
-      it 'assigns expected values to audio properties.' do
-        expect(file.mime_type).to eq("audio/mpeg")
-        expect(file.duration).to eq(["0:0:15:261"])
-        expect(file.sample_rate).to eq(["44100"])
+      context 'with fits_0.8.5' do
+        let(:fits_filename) { 'fits_0.8.5_mp3.xml' }
+        it 'assigns expected values to audio properties.' do
+          expect(file.mime_type).to eq("audio/mpeg")
+          expect(file.duration).to eq(["0:0:15:261"])
+          expect(file.bit_rate).to include("192000")
+          expect(file.sample_rate).to eq(["44100"])
+        end
+      end
+
+      context 'with fits_1.2.0' do
+        let(:fits_filename) { 'fits_1.2.0_mp3.xml' }
+        it 'assigns expected values to audio properties.' do
+          expect(file.mime_type).to eq("audio/mpeg")
+          expect(file.duration).to eq(["0:0:15:261"])
+          expect(file.bit_rate).to include("192000")
+          expect(file.sample_rate).to eq(["44100"])
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #331.

The latest Fits version and many versions before use a different tool (mediainfo) for analysis of audio and video files than was used in prior versions of Fits leading to output with fields in different locations.  This PR adds support for the new locations for data while retaining support for the old locations.

Also included in this PR:
- Add aspect ratio for newer Fits
- Pin activesupport to <5.2 to deal with issues in latest ActiveFedora with Rails 5.2