### PR TITLE
Update hydra-file_characterization version

### DIFF
--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2.10', '< 6.0'
   spec.add_dependency 'hydra-derivatives', '~> 3.0'
-  spec.add_dependency 'hydra-file_characterization', '~> 0.3', '>= 0.3.3'
+  spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
 
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
This updates the `hydra-file_characterization` to
the newer 1.x versions. 1.0.0 was released in
August of 2018 and 1.1 was released in May 2019.