### PR TITLE
Adding Ruby 2.7.z and Rails 6.y.z releases to the CircleCI build configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,6 @@ workflows:
           ruby_version: 2.5.7
           rails_version: 6.0.2
       - test:
-          name: ruby2-4_rails6-0
-          ruby_version: 2.4.9
-          rails_version: 6.0.2
-      - test:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.0
           rails_version: 5.2.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,45 +35,45 @@ workflows:
     jobs:
       - test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.0
-          rails_version: 6.0.2
+          ruby_version: 2.7.1
+          rails_version: 6.0.3.1
       - test:
           name: ruby2-6_rails6-0
-          ruby_version: 2.6.5
-          rails_version: 6.0.2
+          ruby_version: 2.6.6
+          rails_version: 6.0.3.1
       - test:
           name: ruby2-5_rails6-0
-          ruby_version: 2.5.7
-          rails_version: 6.0.2
+          ruby_version: 2.5.8
+          rails_version: 6.0.3.1
       - test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.0
-          rails_version: 5.2.4
+          ruby_version: 2.7.1
+          rails_version: 5.2.4.3
       - test:
           name: ruby2-6_rails5-2
-          ruby_version: 2.6.5
-          rails_version: 5.2.4
+          ruby_version: 2.6.6
+          rails_version: 5.2.4.3
       - test:
           name: ruby2-5_rails5-2
-          ruby_version: 2.5.7
-          rails_version: 5.2.4
+          ruby_version: 2.5.8
+          rails_version: 5.2.4.3
       - test:
           name: ruby2-4_rails5-2
-          ruby_version: 2.4.9
-          rails_version: 5.2.4
+          ruby_version: 2.4.10
+          rails_version: 5.2.4.3
       - test:
           name: ruby2-7_rails5-1
-          ruby_version: 2.7.0
+          ruby_version: 2.7.1
           rails_version: 5.1.7
       - test:
           name: ruby2-6_rails5-1
-          ruby_version: 2.6.5
+          ruby_version: 2.6.6
           rails_version: 5.1.7
       - test:
           name: ruby2-5_rails5-1
-          ruby_version: 2.5.7
+          ruby_version: 2.5.8
           rails_version: 5.1.7
       - test:
           name: ruby2-4_rails5-1
-          ruby_version: 2.4.9
+          ruby_version: 2.4.10
           rails_version: 5.1.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,26 +34,50 @@ workflows:
   ci:
     jobs:
       - test:
+          name: ruby2-7_rails6-0
+          ruby_version: 2.7.0
+          rails_version: 6.0.2
+      - test:
+          name: ruby2-6_rails6-0
+          ruby_version: 2.6.5
+          rails_version: 6.0.2
+      - test:
+          name: ruby2-5_rails6-0
+          ruby_version: 2.5.7
+          rails_version: 6.0.2
+      - test:
+          name: ruby2-4_rails6-0
+          ruby_version: 2.4.9
+          rails_version: 6.0.2
+      - test:
+          name: ruby2-7_rails5-2
+          ruby_version: 2.7.0
+          rails_version: 5.2.4
+      - test:
           name: ruby2-6_rails5-2
-          ruby_version: 2.6.3
-          rails_version: 5.2.3
+          ruby_version: 2.6.5
+          rails_version: 5.2.4
       - test:
           name: ruby2-5_rails5-2
-          ruby_version: 2.5.5
-          rails_version: 5.2.3
+          ruby_version: 2.5.7
+          rails_version: 5.2.4
       - test:
           name: ruby2-4_rails5-2
-          ruby_version: 2.4.6
-          rails_version: 5.2.3
+          ruby_version: 2.4.9
+          rails_version: 5.2.4
+      - test:
+          name: ruby2-7_rails5-1
+          ruby_version: 2.7.0
+          rails_version: 5.1.7
       - test:
           name: ruby2-6_rails5-1
-          ruby_version: 2.6.3
+          ruby_version: 2.6.5
           rails_version: 5.1.7
       - test:
           name: ruby2-5_rails5-1
-          ruby_version: 2.5.5
+          ruby_version: 2.5.7
           rails_version: 5.1.7
       - test:
           name: ruby2-4_rails5-1
-          ruby_version: 2.4.6
+          ruby_version: 2.4.9
           rails_version: 5.1.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,23 +57,3 @@ workflows:
           name: ruby2-5_rails5-2
           ruby_version: 2.5.8
           rails_version: 5.2.4.3
-      - test:
-          name: ruby2-4_rails5-2
-          ruby_version: 2.4.10
-          rails_version: 5.2.4.3
-      - test:
-          name: ruby2-7_rails5-1
-          ruby_version: 2.7.1
-          rails_version: 5.1.7
-      - test:
-          name: ruby2-6_rails5-1
-          ruby_version: 2.6.6
-          rails_version: 5.1.7
-      - test:
-          name: ruby2-5_rails5-1
-          ruby_version: 2.5.8
-          rails_version: 5.1.7
-      - test:
-          name: ruby2-4_rails5-1
-          ruby_version: 2.4.10
-          rails_version: 5.1.7

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hydra-works.gemspec
 gemspec
 
+gem 'hydra-derivatives', git: 'https://github.com/jrgriffiniii/hydra-derivatives.git', branch: 'rails6-update'
 gem 'slop', '~> 3.6' # For byebug
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hydra-works.gemspec
 gemspec
 
-gem 'active-fedora', git: 'https://github.com/jrgriffiniii/active_fedora.git', branch: 'rails6-update'
-gem 'hydra-derivatives', git: 'https://github.com/jrgriffiniii/hydra-derivatives.git', branch: 'rails6-update'
 gem 'slop', '~> 3.6' # For byebug
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,10 @@ gem 'hydra-derivatives', git: 'https://github.com/jrgriffiniii/hydra-derivatives
 gem 'slop', '~> 3.6' # For byebug
 
 group :development, :test do
-  # gem 'rubocop', '~> 0.47.0', require: false
-  gem 'rubocop', require: false
-  # gem 'rubocop-rspec', '~> 1.13.0', require: false
-  gem 'rubocop-rspec', require: false
-  gem 'pry' unless ENV['CI']
-  gem 'pry-byebug' unless ENV['CI']
   gem 'clamby'
+  gem 'pry-byebug' unless ENV['CI']
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 if ENV['RAILS_VERSION']
@@ -23,8 +20,4 @@ if ENV['RAILS_VERSION']
   else
     gem 'rails', ENV['RAILS_VERSION']
   end
-else
-  gem 'actionpack', '5.1.7'
-  gem 'activemodel', '5.1.7'
-  gem 'rails', '5.1.7'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,10 @@ gem 'hydra-derivatives', git: 'https://github.com/jrgriffiniii/hydra-derivatives
 gem 'slop', '~> 3.6' # For byebug
 
 group :development, :test do
-  gem 'rubocop', '~> 0.47.0', require: false
-  gem 'rubocop-rspec', '~> 1.13.0', require: false
+  # gem 'rubocop', '~> 0.47.0', require: false
+  gem 'rubocop', require: false
+  # gem 'rubocop-rspec', '~> 1.13.0', require: false
+  gem 'rubocop-rspec', require: false
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
   gem 'clamby'
@@ -21,4 +23,8 @@ if ENV['RAILS_VERSION']
   else
     gem 'rails', ENV['RAILS_VERSION']
   end
+else
+  gem 'actionpack', '5.1.7'
+  gem 'activemodel', '5.1.7'
+  gem 'rails', '5.1.7'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hydra-works.gemspec
 gemspec
 
+gem 'active-fedora', git: 'https://github.com/jrgriffiniii/active_fedora.git', branch: 'rails6-update'
 gem 'hydra-derivatives', git: 'https://github.com/jrgriffiniii/hydra-derivatives.git', branch: 'rails6-update'
 gem 'slop', '~> 3.6' # For byebug
 

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 4.2.10', '< 6.0'
-  spec.add_dependency 'hydra-derivatives', '~> 3.0'
+  spec.add_dependency 'activesupport', '>= 4.2.10', '< 7.0'
   spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
 
@@ -29,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'solr_wrapper', '~> 2.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec_junit_formatter'

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2.10', '< 7.0'
+  # spec.add_dependency 'hydra-derivatives'
   spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
 
@@ -28,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'solr_wrapper', '~> 2.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec_junit_formatter'

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2.10', '< 7.0'
-  spec.add_dependency 'hydra-derivatives', '~> 3.5'
+  spec.add_dependency 'hydra-derivatives', '~> 3.6'
   spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
 

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2.10', '< 7.0'
-  # spec.add_dependency 'hydra-derivatives'
+  spec.add_dependency 'hydra-derivatives', '~> 3.5'
   spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 4.2.10', '< 7.0'
+  spec.add_dependency 'activesupport', '>= 5.2', '< 7.0'
   spec.add_dependency 'hydra-derivatives', '~> 3.6'
   spec.add_dependency 'hydra-file_characterization', '~> 1.0'
   spec.add_dependency 'hydra-pcdm', '>= 0.9'
@@ -33,8 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solr_wrapper', '~> 2.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec_junit_formatter'
-
-  ### Pinned dependencies
-  # Pin sprockets to < 4 since it requires ruby 2.5+
-  spec.add_dependency 'sprockets', '< 4'
 end


### PR DESCRIPTION
Supersedes #375 by dropping dependency pins now that dependencies have been released.